### PR TITLE
Add z-index rule to CSS

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -15,6 +15,7 @@ nav {
     width: 60em;
     padding: 10px;
     background-image: linear-gradient(to bottom, #e0f0f0, #ffffff);
+    z-index: 1000; /* To be on top of MathJax */
 }
 
 nav div.left {


### PR DESCRIPTION
This will resolve the bug of have the MathJax element
on top of the navigation bar.

Before:

![bug](https://user-images.githubusercontent.com/1506457/70652972-7f2cf880-1c4b-11ea-9508-de6fc2ab7d0b.png)

After:

![fixed](https://user-images.githubusercontent.com/1506457/70652988-83f1ac80-1c4b-11ea-893e-7a002bcb2b8f.png)
